### PR TITLE
Add discount result fragment

### DIFF
--- a/gql/fragments/discount.ts
+++ b/gql/fragments/discount.ts
@@ -35,3 +35,20 @@ export const CART_TOTALS_FRAGMENT = gql`
         savings_percentage
     }
 `;
+
+export const DISCOUNT_APPLICATION_RESULT_FRAGMENT = gql`
+    fragment DiscountApplicationResult on ClientDiscountApplicationResult {
+        discount {
+            ...AppliedDiscount
+        }
+        error_message
+        new_cart_total
+        promocode_id
+        success
+        totals {
+            ...CartTotals
+        }
+    }
+    ${APPLIED_DISCOUNT_FRAGMENT}
+    ${CART_TOTALS_FRAGMENT}
+`;

--- a/gql/mutations/discount.ts
+++ b/gql/mutations/discount.ts
@@ -1,40 +1,20 @@
 import { gql } from 'graphql-tag';
-import { APPLIED_DISCOUNT_FRAGMENT, CART_TOTALS_FRAGMENT } from '~/gql/fragments/discount';
+import { DISCOUNT_APPLICATION_RESULT_FRAGMENT } from '~/gql/fragments/discount';
 
 export const APPLY_PROMOCODE = gql`
     mutation applyClientCartPromocodeDiscount($code: String!) {
         applyClientCartPromocodeDiscount(code: $code) {
-            discount {
-                ...AppliedDiscount
-            }
-            error_message
-            new_cart_total
-            promocode_id
-            success
-            totals {
-                ...CartTotals
-            }
+            ...DiscountApplicationResult
         }
     }
-    ${APPLIED_DISCOUNT_FRAGMENT}
-    ${CART_TOTALS_FRAGMENT}
+    ${DISCOUNT_APPLICATION_RESULT_FRAGMENT}
 `;
 
 export const REMOVE_PROMOCODE = gql`
     mutation removeClientCartPromocodeDiscount($promocode_id: Int!) {
         removeClientCartPromocodeDiscount(promocode_id: $promocode_id) {
-            discount {
-                ...AppliedDiscount
-            }
-            error_message
-            new_cart_total
-            promocode_id
-            success
-            totals {
-                ...CartTotals
-            }
+            ...DiscountApplicationResult
         }
     }
-    ${APPLIED_DISCOUNT_FRAGMENT}
-    ${CART_TOTALS_FRAGMENT}
+    ${DISCOUNT_APPLICATION_RESULT_FRAGMENT}
 `;

--- a/types/Discount.ts
+++ b/types/Discount.ts
@@ -1,3 +1,5 @@
+import * as v from 'valibot';
+
 export type AppliedDiscount = {
     id: number;
     name: string;
@@ -27,3 +29,24 @@ export type CartTotals = {
     original_amount: number;
     savings_percentage: number;
 };
+
+export type DiscountApplicationResult = {
+    discount: AppliedDiscount | null;
+    error_message: string | null;
+    new_cart_total: number | null;
+    promocode_id: number | null;
+    success: boolean | null;
+    totals: CartTotals | null;
+};
+
+export const ApplyPromocodeFieldsSchema = v.object({
+    code: v.pipe(v.string(), v.nonEmpty('Введите промокод')),
+});
+
+export type ApplyPromocodeFields = v.InferOutput<typeof ApplyPromocodeFieldsSchema>;
+
+export const RemovePromocodeFieldsSchema = v.object({
+    promocode_id: v.number(),
+});
+
+export type RemovePromocodeFields = v.InferOutput<typeof RemovePromocodeFieldsSchema>;


### PR DESCRIPTION
## Summary
- refactor discount GraphQL operations
- add `DiscountApplicationResult` fragment
- add matching types and Valibot schemas

## Testing
- `bun lint`

------
https://chatgpt.com/codex/tasks/task_e_68738c69dc0c832bb26d52b2bdc8e1d1